### PR TITLE
fixed bugs

### DIFF
--- a/Node.java
+++ b/Node.java
@@ -288,7 +288,9 @@ public class Node {
         }
 
 
-
+        Cursor tempFind = leafNodeFind(cursor.getTable(), oldPageNum, key);
+        int insertIndex = tempFind.getCellNum();
+        
 
         int newPageNum = pager.getNumPages();
         ByteBuffer newNode = pager.getPage(newPageNum);
@@ -308,8 +310,7 @@ public class Node {
 
 
 
-        Cursor tempFind = leafNodeFind(cursor.getTable(), oldPageNum, key);
-        int insertIndex = tempFind.getCellNum();
+
 
 
 

--- a/SimpleDatabase.java
+++ b/SimpleDatabase.java
@@ -156,7 +156,7 @@ public class SimpleDatabase {
 
 
             executeStatement(statement,table);
-            System.out.println("Executed.");
+            // System.out.println("Executed.");
            
         }
 


### PR DESCRIPTION
1.Two executed statements were appearing after performing the insert operation. 

2.While splitting the node, the control was setting the old node’s numCells (number of cells in the node) to zero before calculating the cursor. This issue has been fixed.